### PR TITLE
link to image.sc post in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The LabelEditor is a JugLab creation aiming to close the gap between segmentation algorithms and user interaction in ImageJ2 / Fiji.
 
+For basic usage instructions [see this thread on image.sc](https://forum.image.sc/t/bdv-labeleditor-objects-counter-ij2-for-dealing-with-labelings-in-imagej-usage/31635).
+
 ## Implementation
 
 ### core


### PR DESCRIPTION
A @ mention in issue #17 brought me to this repo, and from looking at the README.md I couldn't figure out what it is about. @haesleinhuepf provided some link with context to image.sc. I think this should also be linked to in the README